### PR TITLE
feat: GitHub MCP 連携フロー確立 — /catchup・/adr スキル整備

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -11,26 +11,23 @@ npm run dev        # tsx src/index.ts (no build step)
 
 ## Registering the MCP Server
 
-Add to `~/.claude/settings.json`:
+Use `claude mcp add` (stored in `~/.claude.json`, not `settings.json`):
 
-```json
-{
-  "mcpServers": {
-    "obsidian-vault": {
-      "type": "http",
-      "url": "http://<LXC_IP>:1065/mcp"
-    }
-  }
-}
+```sh
+# Obsidian Vault (HTTP, LXC server)
+claude mcp add obsidian-vault --transport http http://<LXC_IP>:1065/mcp
+
+# GitHub (stdio, local binary)
+claude mcp add github -- sh -c 'GITHUB_PERSONAL_ACCESS_TOKEN=$(gh auth token) ~/.local/bin/github-mcp-server stdio'
 ```
 
 `VAULT_PATH` on the server should point to the `claude/` subdirectory of your Obsidian Vault.
 
 ## Skills
 
-### `/orient`
+### `/catchup`
 
-Load recent context (AGENTS.md + devlog). **Suggest proactively** at session start or when context feels stale.
+Load recent context (AGENTS.md + devlog + tmp/ handoff notes). **Suggest proactively** at session start or when context feels stale.
 
 ### `/devlog`
 

--- a/.claude/skills/adr.md
+++ b/.claude/skills/adr.md
@@ -12,9 +12,26 @@ vault_search query="tag: adr" path_filter="adr/*.md"
 
 Count the results. Next ADR number = count + 1. If no results, start at ADR-001.
 
-### 2. Draft ADR from session context
+### 2. Fetch GitHub references (optional)
 
-From the current conversation, identify the decision being made and auto-generate:
+Ask the user:
+
+> 関連する GitHub Issue/PR の URL があれば教えてください（任意、複数可。例: https://github.com/owner/repo/issues/42）:
+
+If URLs are provided, for each one:
+- Parse the URL to extract: `owner`, `repo`, `number`, and type (`issues` → issue / `pull` → PR)
+- Call the appropriate tool from the `github` MCP server:
+  - Issue: `issue_read` with `{ owner, repo, issueNumber: number }`
+  - PR: `pull_request_read` with `{ owner, repo, pullNumber: number }`
+- Extract: title, body, state, labels
+
+Collect all fetched references. These will be used to enrich the ADR draft and populate `related:`.
+
+If no URLs are provided, skip this step.
+
+### 3. Draft ADR from session context
+
+From the current conversation (and fetched GitHub context if available), identify the decision being made and auto-generate:
 
 ```markdown
 ---
@@ -24,12 +41,15 @@ date: {YYYY-MM-DD}
 status: accepted
 project: {project-name}
 related:
+  - {GitHub URL 1}
+  - {GitHub URL 2}
 ---
 
 # ADR-{NNN}: {title}
 
 ## Context
 {Why was this decision necessary? What problem does it solve?}
+{If GitHub refs were fetched, summarize relevant background from issue/PR body and discussion.}
 
 ## Options Considered
 1. **{Option A}** — {pros/cons}
@@ -42,9 +62,10 @@ related:
 {Trade-offs, implications, things that follow from this decision}
 ```
 
-Show the draft to the user. Ask for confirmation or edits before saving.
+- If no GitHub refs: `related:` is an empty list `[]`
+- Show the draft to the user. Ask for confirmation or edits before saving.
 
-### 3. Save ADR to Vault
+### 4. Save ADR to Vault
 
 Determine the slug from the title (lowercase, hyphen-separated):
 
@@ -52,10 +73,10 @@ Determine the slug from the title (lowercase, hyphen-separated):
 note_upsert
   path="adr/ADR-{NNN}-{slug}.md"
   content="{full body without frontmatter}"
-  frontmatter={ tags: ["adr", "accepted"], adr: {N}, date: "{YYYY-MM-DD}", status: "accepted", project: "{project-name}", related: [] }
+  frontmatter={ tags: ["adr", "accepted"], adr: {N}, date: "{YYYY-MM-DD}", status: "accepted", project: "{project-name}", related: ["{url1}", "{url2}"] }
 ```
 
-### 4. Update _index.md
+### 5. Update _index.md
 
 Append the new entry to the ADR index:
 
@@ -72,4 +93,5 @@ Confirm to the user: "ADR-{NNN} saved at adr/ADR-{NNN}-{slug}.md"
 - project-name: infer from current working directory or CLAUDE.md
 - Use zero-padded 3-digit number for NNN (e.g., 001, 012)
 - If the decision is still being debated, set status: proposed instead of accepted
-- MCP server must be registered in `~/.claude/settings.json` as `obsidian-vault`
+- `obsidian-vault` MCP server: registered in `~/.claude.json` via `claude mcp add`
+- `github` MCP server: registered in `~/.claude.json` via `claude mcp add github -- sh -c '...'`

--- a/.claude/skills/catchup.md
+++ b/.claude/skills/catchup.md
@@ -1,10 +1,10 @@
-You are executing the /orient command. Load current project context from AGENTS.md and the Obsidian Vault devlog.
+You are executing the /catchup command. Load current project context from AGENTS.md, the Obsidian Vault devlog, and any pending handoff notes.
 
 ## Purpose
 
-Recover recent progress and active decisions from the Obsidian Vault without relying on conversation history.
+Recover recent progress, open problems, and next actions from the Obsidian Vault — without relying on conversation history.
 
-**This skill is intended for proactive use.** You (Claude) should suggest running `/orient` when:
+**This skill is intended for proactive use.** You (Claude) should suggest running `/catchup` when:
 - A new session starts and the user's task seems project-related
 - The conversation context feels stale or you're unsure of recent changes
 - The user asks "where were we?" or refers to past work vaguely
@@ -43,7 +43,23 @@ Extract and display the **last 10 entries** (most recent first, sorted by date i
 
 Highlight any lines containing `未解決` — these are unresolved issues that may need attention.
 
-### 5. Read ADR index (optional)
+### 5. Check for handoff notes (tmp/)
+
+Search for pending verification or handoff notes:
+
+```
+vault_search query="." path_filter="tmp/*.md"
+```
+
+If any exist, read them:
+
+```
+note_read path="tmp/{filename}.md"
+```
+
+Surface the contents as **"持ち越しタスク"** in the report.
+
+### 6. Read ADR index (optional)
 
 ```
 note_read path="_index.md"
@@ -51,9 +67,10 @@ note_read path="_index.md"
 
 If it exists, show the table of ADRs for reference.
 
-### 6. Report
+### 7. Report
 
 Summarize in bullet form:
+- **持ち越しタスク** — contents of any `tmp/` notes (highest priority)
 - **Recent work** — last 3–5 `[impl]` / `[verify]` entries
 - **Open problems** — any `未解決` items
 - **Active decisions** — latest ADR(s), if any
@@ -62,6 +79,6 @@ Keep the summary concise. Do not repeat raw log lines verbatim unless asked.
 
 ## Notes
 
-- MCP server must be registered as `obsidian-vault` in `~/.claude/settings.json`
+- `obsidian-vault` MCP server: registered in `~/.claude.json` via `claude mcp add`
 - If no devlog file matches the current project, say so and suggest running `/devlog` to create one
 - This skill is read-only — it never writes to the vault


### PR DESCRIPTION
## Summary

- `/orient` → `/catchup` にリネーム（tmp/ ハンドオフステップ追加）
- `/adr` スキルに GitHub 参照ステップを追加（`issue_read` / `pull_request_read` で Issue/PR 内容を ADR に自動反映）
- `github-mcp-server` MCP ツール群の動作を本セッションで実証（`list_issues`, `list_pull_requests`, `issue_read`, `pull_request_read`）
- ADR-001（github-mcp-server 採用）・ADR-002（GitHub Issue/PR を ADR 起点とする運用フロー）を Vault に保存

Closes #3
Closes #1

## Test plan

- [ ] `/catchup` スキルが AGENTS.md + devlog + tmp/ を正常にロードする
- [ ] `/adr` スキルが Issue/PR 参照 → Vault 保存 → `_index.md` 更新を正常に完了する
- [ ] `list_issues` / `issue_read` 等の GitHub MCP ツールがセッション再起動後も動作する

🤖 Generated with [Claude Code](https://claude.com/claude-code)