### PR TITLE
feat: add systemd service and launch.sh for deploy

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,3 +43,40 @@ All tools are exposed at `POST /mcp` via MCP Streamable HTTP.
 | `vault_search` | Full-text search with ripgrep. Accepts `query` (regex) and optional `path_filter` (glob). |
 
 See [`AGENTS.md`](./AGENTS.md) for full input/output specs.
+
+## Deploy
+
+### LXC Server (systemd)
+
+```sh
+# 1. リポジトリをクローン・ビルド
+git clone <repo> /opt/obsidian-vault-mcp
+cd /opt/obsidian-vault-mcp
+npm install && npm run build
+
+# 2. 環境変数ファイルを作成
+cp .env.example /etc/obsidian-vault-mcp.env
+# VAULT_PATH と PORT を編集する
+vi /etc/obsidian-vault-mcp.env
+
+# 3. systemd ユニットをインストール
+cp systemd/obsidian-vault-mcp.service /etc/systemd/system/
+systemctl daemon-reload
+systemctl enable --now obsidian-vault-mcp
+
+# ログ確認
+journalctl -u obsidian-vault-mcp -f
+```
+
+> `rclone-vault.service` で Google Drive をマウント済みであることが前提です。
+> `After=rclone-vault.service` により、マウント完了後に MCP サーバーが起動します。
+
+### localhost (Mac / Linux desktop)
+
+```sh
+npm install && npm run build
+VAULT_PATH=/path/to/vault ./launch.sh
+
+# バックグラウンド起動
+nohup ./launch.sh &
+```

--- a/launch.sh
+++ b/launch.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+# launch.sh — localhost (Mac / Linux desktop) 向け起動スクリプト
+# 使い方: ./launch.sh
+# バックグラウンド起動: nohup ./launch.sh &
+
+export VAULT_PATH="${VAULT_PATH:-$HOME/obsidian-vault/claude}"
+export PORT="${PORT:-1065}"
+
+exec node "$(dirname "$0")/dist/index.js"

--- a/systemd/obsidian-vault-mcp.service
+++ b/systemd/obsidian-vault-mcp.service
@@ -1,0 +1,13 @@
+[Unit]
+Description=Obsidian Vault MCP Server
+After=network.target rclone-vault.service
+
+[Service]
+WorkingDirectory=/opt/obsidian-vault-mcp
+EnvironmentFile=/etc/obsidian-vault-mcp.env
+ExecStart=/usr/bin/node dist/index.js
+Restart=on-failure
+RestartSec=5
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
## Summary

- `systemd/obsidian-vault-mcp.service` を追加（LXC 常駐用、`After=rclone-vault.service`）
- `launch.sh` を追加（Mac / localhost 向け起動スクリプト）
- README に Deploy セクションを追加（両環境の手順）

## 背景

issue #6 の検討結果として ADR-001 で systemd 採用を決定。  
ただし LXC へのデプロイが当面不要な可能性があるため、Draft で保留。

## 関連

- Closes #6
- Mac 向け Obsidian CLI バックエンドの実装は #12 で追跡

## 保留事項

- [ ] LXC へ実際にインストールするタイミングで Draft を解除する
- [ ] Mac 向けに Obsidian CLI バックエンドが実装されたら launch.sh の README を更新する